### PR TITLE
I've made some changes to address the ImportError in the certificate_…

### DIFF
--- a/app/utils/pdf_generator.py
+++ b/app/utils/pdf_generator.py
@@ -37,7 +37,7 @@ def _add_korean_font(pdf_instance):
         )
     )
 
-def generate_prescription_pdf(patient_name, patient_rrn, department, prescriptions, total_fee):
+def create_prescription_pdf_bytes(patient_name, patient_rrn, department, prescriptions, total_fee):
     pdf = FPDF()
     pdf.add_page()
     _add_korean_font(pdf)
@@ -91,7 +91,7 @@ def generate_prescription_pdf(patient_name, patient_rrn, department, prescriptio
         return pdf_bytes.encode("latin-1")
     return bytes(pdf_bytes)
 
-def generate_medical_confirmation_pdf(patient_name, patient_rrn, disease_name):
+def create_confirmation_pdf_bytes(patient_name, patient_rrn, disease_name):
     pdf = FPDF()
     pdf.add_page()
     _add_korean_font(pdf)


### PR DESCRIPTION
…service.

I renamed some functions in `app/utils/pdf_generator.py` to match the import statements in `app/services/certificate_service.py`.

Specifically:
- `generate_prescription_pdf` is now `create_prescription_pdf_bytes`
- `generate_medical_confirmation_pdf` is now `create_confirmation_pdf_bytes`

This should resolve the error:
ImportError: cannot import name 'create_prescription_pdf_bytes' from 'app.utils.pdf_generator'