### PR TITLE
Fix: Correct KeyError in CSV lookup and update tests

### DIFF
--- a/app/services/reception_service.py
+++ b/app/services/reception_service.py
@@ -66,7 +66,7 @@ def lookup_reservation(name: str, rrn: str) -> dict | None:
             reservations = list(csv.DictReader(f))
 
         for res in reservations:
-            if res["Name"] == name and res["RRN"] == rrn:
+            if res["name"] == name and res["rrn"] == rrn:
                 return res # Return the entire reservation dict
         return None
     except FileNotFoundError:

--- a/tests/services/test_reception_service.py
+++ b/tests/services/test_reception_service.py
@@ -14,7 +14,7 @@ from app.services.reception_service import (
     SYM_TO_DEPT # Import for context if needed
 )
 
-MOCK_RESERVATIONS_CSV_DATA = """Name,RRN,Department,Time,Location,Doctor
+MOCK_RESERVATIONS_CSV_DATA = """name,rrn,department,time,location,doctor
 김예약,850101-1234567,내과,10:00,본관1층,닥터김
 박테스트,920202-2345678,외과,14:30,별관2층,닥터박
 """
@@ -32,9 +32,9 @@ class TestReceptionService(unittest.TestCase):
         result = lookup_reservation(name, rrn)
 
         self.assertIsNotNone(result)
-        self.assertEqual(result["Name"], name) # CSV DictReader uses original header names
-        self.assertEqual(result["RRN"], rrn)
-        self.assertEqual(result["Department"], "내과")
+        self.assertEqual(result["name"], name)
+        self.assertEqual(result["rrn"], rrn)
+        self.assertEqual(result["department"], "내과")
 
     @patch('app.services.reception_service.os.path.exists', return_value=True)
     @patch('builtins.open')


### PR DESCRIPTION
Corrects a KeyError in the `lookup_reservation` function in `app/services/reception_service.py`. The function was attempting to access data from `reservations.csv` using uppercase dictionary keys ('Name', 'RRN'), but the CSV file uses lowercase headers ('name', 'rrn'). This change updates the code to use the correct lowercase keys.

Additionally, this commit updates `tests/services/test_reception_service.py`:
- Modifies `MOCK_RESERVATIONS_CSV_DATA` to use lowercase headers, matching the actual CSV file format.
- Adjusts assertions in `test_lookup_reservation_existing` to use lowercase keys, ensuring the test accurately validates the fixed code and the production data structure.

This resolves the issue where you present in `reservations.csv` could not be found via manual input in the reception interface.