### PR TITLE
Fix: Resolve TypeError in reception route for render_template

### DIFF
--- a/app/routes/reception.py
+++ b/app/routes/reception.py
@@ -32,7 +32,7 @@ def reception():
 
             if scan_result["reservation_details"]:
                 return render_template("reception.html", step="reserved",
-                                       name=scan_result["name"], **scan_result["reservation_details"])
+                                       **scan_result["reservation_details"])
             else:
                 return render_template("reception.html", step="symptom",
                                        name=scan_result["name"], rrn=scan_result["rrn"], symptoms=SYMPTOMS)
@@ -53,7 +53,7 @@ def reception():
 
             if reservation_details:
                 return render_template("reception.html", step="reserved",
-                                       name=name, **reservation_details)
+                                       **reservation_details)
             else:
                 return render_template("reception.html", step="symptom",
                                        name=name, rrn=rrn, symptoms=SYMPTOMS)


### PR DESCRIPTION
Corrects a TypeError in `app/routes/reception.py` that occurred when rendering the "reception.html" template after a reservation was found for both "manual" and "scan" actions.

The error `TypeError: flask.templating.render_template() got multiple values for keyword argument 'name'` was caused by explicitly passing `name=...` as a keyword argument while also unpacking a `reservation_details` dictionary (or `scan_result["reservation_details"]`) that already contained a 'name' key.

This commit removes the redundant explicit `name` argument in the `render_template` calls for these cases, relying on the unpacked dictionary to provide the necessary template variables.