### PR TITLE
Fix: Resolve certificate PDF generation failure due to missing data file

### DIFF
--- a/app/data/prescriptions.csv
+++ b/app/data/prescriptions.csv
@@ -1,0 +1,6 @@
+name,code,unit_dose,daily_frequency,total_days
+비타민D 처방,VITD001,1정,1회,30일
+철분제 처방,IRON002,1캡슐,1회,60일
+위장약 처방,STOM003,1포,3회,7일
+기관지확장제 처방,BRONCH01,2퍼프,4회,14일
+항히스타민제 처방,ANTIHI01,1정,1회,10일


### PR DESCRIPTION
Addresses an issue where generating a prescription PDF from `/certificate/prescription/` would fail and redirect to `/payment/?error=failed_to_load_prescription_details`.

The root cause was that the `get_prescription_data_for_pdf` function in `app/services/certificate_service.py` was returning `None` because it could not find the required prescription detail CSV files (neither department-specific `prescriptions_<dept>.csv` nor the fallback `prescriptions.csv` in the `app/data/` directory, as the directory was empty).

This commit resolves the issue by adding a sample
`app/data/prescriptions.csv` file with a header and a few rows of data. This allows the certificate service to find and process a fallback data file, preventing the `None` return that led to the error redirect.

The certificate generation process should now proceed further. Existing unit tests for `certificate_service.py` already cover the logic for handling the presence or absence of this fallback file using mocks.