### PR TITLE
Refactor: Ensure patient status is sourced from CSV and update tests

### DIFF
--- a/app/routes/payment.py
+++ b/app/routes/payment.py
@@ -89,7 +89,6 @@ def load_prescriptions():
     # or adjust client. The task description for service said "return a dictionary containing
     # `prescriptions` and `total_fee`".
     # The original route returned: {"Prescription": row["Prescription"], "Fee": float(row["Fee"])}
-    # The service currently returns: {"prescriptions": [name1, name2], "total_fee": total_fee}
     # Let's assume for now the client needs the detailed objects.
     # I will need to modify the service `load_department_prescriptions`
     # OR I modify what's stored in session and what `certificate_service` expects.
@@ -136,8 +135,6 @@ def load_prescriptions():
     # The service should be the one providing the correct format for this route.
     # I will proceed assuming the service output IS ALREADY what the client expects.
     # This means the service returns: {'prescriptions': [{'name': ..., 'fee': ...}], 'total_fee': ...}
-    # The previous service code was:
-    # `return {"prescriptions": selected_prescription_names, "total_fee": total_fee}`
     # This needs correction in the service file.
     # I will make that correction to the service file first.
 

--- a/tests/services/test_reception_service.py
+++ b/tests/services/test_reception_service.py
@@ -14,9 +14,9 @@ from app.services.reception_service import (
     SYM_TO_DEPT # Import for context if needed
 )
 
-MOCK_RESERVATIONS_CSV_DATA = """name,rrn,department,time,location,doctor
-김예약,850101-1234567,내과,10:00,본관1층,닥터김
-박테스트,920202-2345678,외과,14:30,별관2층,닥터박
+MOCK_RESERVATIONS_CSV_DATA = """name,rrn,department,time,location,doctor,status,transcription,amount
+김예약,850101-1234567,내과,10:00,본관1층,닥터김,Pending,,0
+박테스트,920202-2345678,외과,14:30,별관2층,닥터박,Pending,,0
 """
 
 class TestReceptionService(unittest.TestCase):
@@ -35,6 +35,9 @@ class TestReceptionService(unittest.TestCase):
         self.assertEqual(result["name"], name)
         self.assertEqual(result["rrn"], rrn)
         self.assertEqual(result["department"], "내과")
+        self.assertEqual(result["status"], "Pending")
+        self.assertEqual(result["transcription"], "")
+        self.assertEqual(result["amount"], "0") # Values from DictReader are strings
 
     @patch('app.services.reception_service.os.path.exists', return_value=True)
     @patch('builtins.open')
@@ -180,7 +183,11 @@ class TestReceptionService(unittest.TestCase):
             # Simulate random.choice returning the first entry from our mock CSV data
             # The data read by csv.DictReader will be a list of dicts
             # Example: [{'Name': '김예약', 'RRN': '850101-1234567', ...}, ...]
-            mock_random_choice.return_value = {"Name": "김예약", "RRN": "850101-1234567"}
+            mock_random_choice.return_value = {
+                "name": "김예약", "rrn": "850101-1234567", "department": "내과",
+                "time": "10:00", "location": "본관1층", "doctor": "닥터김",
+                "status": "Pending", "transcription": "", "amount": "0"
+            }
 
             name, rrn = fake_scan_rrn()
 


### PR DESCRIPTION
This commit addresses the requirement that patient status information should always be fetched directly from `reservations.csv` and not from the session.

Investigations across `app/routes/` and `app/services/` confirmed that the application generally adheres to this principle, with `reception_service.lookup_reservation` being the primary function for fetching full patient records, including status. No significant logic changes were needed in the main application code to enforce this.

Key changes in this commit:

1.  Updated `tests/services/test_reception_service.py`:
    - Modified `MOCK_RESERVATIONS_CSV_DATA` to include the new `status`, `transcription`, and `amount` columns.
    - Enhanced assertions in `test_lookup_reservation_existing` to verify that these new fields are correctly returned.
    - Updated the mock return value in `test_fake_scan_rrn_reads_from_csv` for consistency with the new CSV schema. This ensures tests accurately reflect the current data structure.

2.  Cleaned up misleading comments in `app/routes/payment.py` within the `load_prescriptions` function that referred to an outdated structure of the data returned by the payment service.