### PR TITLE
Fix: Correct KeyError when loading prescriptions in payment route

### DIFF
--- a/app/routes/payment.py
+++ b/app/routes/payment.py
@@ -79,7 +79,7 @@ def load_prescriptions():
 
     # Store prescription names and total fee in session for certificate generation
     # The service now returns a list of names directly in result["prescriptions"]
-    session["last_prescriptions"] = result["prescriptions"]
+    session["last_prescriptions"] = result["prescription_names"]
     session["last_total_fee"] = result["total_fee"]
 
     # The client-side JavaScript in payment.html expects a list of objects,


### PR DESCRIPTION
The `load_prescriptions` route in `app/routes/payment.py` was attempting to access `result["prescriptions"]` to store prescription names in the session. However, the `load_department_prescriptions` service function returns these names under the key `result["prescription_names"]`.

This commit changes the line to use the correct key `result["prescription_names"]`, resolving the `KeyError: 'prescriptions'` and allowing the list of prescription names to be correctly stored in the session for later use (e.g., by the certificate service).