### PR TITLE
Feat: Update reservations.csv with payment details and use for certif… (reservations.csv를 shared해서 모든 서비스가 쓰도록 수정)

### DIFF
--- a/app/routes/payment.py
+++ b/app/routes/payment.py
@@ -11,6 +11,7 @@ from app.services.payment_service import (
     process_new_payment,
     get_payment_details,
     load_department_prescriptions,
+    update_reservation_with_payment_details,
 )
 
 # ──────────────────────────────────────────────────────────
@@ -56,6 +57,27 @@ def payment():
             amount=amount,
             method=method
         )
+
+        # Update reservation with prescription details
+        patient_rrn_for_reservation_update = session.get("patient_rrn")
+        # 'last_prescriptions' should hold the list of names from load_prescriptions route
+        prescription_names_to_save = session.get("last_prescriptions")
+        # 'last_total_fee' should hold the total fee from load_prescriptions route
+        total_fee_to_save = session.get("last_total_fee")
+
+        if patient_rrn_for_reservation_update and \
+           prescription_names_to_save is not None and \
+           total_fee_to_save is not None:
+            # Optionally, log the result or handle failure
+            update_reservation_with_payment_details(
+                patient_rrn_for_reservation_update,
+                prescription_names_to_save,
+                total_fee_to_save
+            )
+        # else:
+            # Optionally, log that some data was missing for reservation update
+            # For example: print("DEBUG: Missing data for reservation update in payment POST")
+
 
         # 완료 페이지로 리다이렉트
         return redirect(url_for("payment.done", pay_id=pay_id))

--- a/app/services/certificate_service.py
+++ b/app/services/certificate_service.py
@@ -8,71 +8,118 @@ from io import BytesIO
 from app.utils.pdf_generator import create_prescription_pdf_bytes, create_confirmation_pdf_bytes, MissingKoreanFontError
 
 
-def get_prescription_data_for_pdf(department: str, last_prescriptions: list, last_total_fee: int):
+def get_prescription_data_for_pdf(patient_rrn: str, department: str):
     """
-    Loads and prepares prescription data for PDF generation.
-    This function encapsulates logic from the original _load_prescription_data
-    and any other data preparation needed for the prescription PDF.
+    Loads and prepares prescription data for PDF generation by fetching
+    details from reservations.csv and then prescription item details.
     """
-    if not last_prescriptions:
+    try:
+        # Determine project base directory
+        base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+        reservations_csv_path = os.path.join(base_dir, "data", "reservations.csv")
+    except NameError:
+        # Fallback if __file__ is not defined
+        reservations_csv_path = os.path.join("data", "reservations.csv") # Assumes PWD is project root
+
+    if not os.path.exists(reservations_csv_path):
+        # print(f"CRITICAL ERROR: reservations.csv not found at {reservations_csv_path}") # Or log this
         return None
 
-    # Simulate loading prescription details from a CSV file based on department
-    # This part is adapted from the original _load_prescription_data
-    filename = f"prescriptions_{department.lower()}.csv"
-    filepath = os.path.join("app", "data", filename)
+    patient_reservation_data = None
+    try:
+        with open(reservations_csv_path, mode='r', encoding='utf-8-sig') as file:
+            reader = csv.DictReader(file)
+            for row in reader:
+                if row.get('rrn') == patient_rrn:
+                    patient_reservation_data = row
+                    break
+    except FileNotFoundError:
+        # print(f"Error: File not found during read: {reservations_csv_path}")
+        return None
+    except Exception as e:
+        # print(f"Error reading {reservations_csv_path}: {e}") # Log other potential CSV errors
+        return None
+
+    if not patient_reservation_data:
+        # print(f"Info: Patient with rrn {patient_rrn} not found in {reservations_csv_path}.")
+        return None
+
+    prescription_names_str = patient_reservation_data.get("prescription_names", "")
+    total_fee_str = patient_reservation_data.get("total_fee", "0")
+
+    if prescription_names_str:
+        parsed_prescription_names = [name.strip() for name in prescription_names_str.split(',') if name.strip()]
+    else:
+        parsed_prescription_names = []
+
+    try:
+        fetched_total_fee = int(total_fee_str)
+    except ValueError:
+        # print(f"Warning: Invalid total_fee format '{total_fee_str}' for patient {patient_rrn}. Defaulting to 0.")
+        fetched_total_fee = 0
+
+    # Department specific prescription file (e.g., prescriptions_소화기내과.csv)
+    department_filename_part = department.lower().replace(" ", "_") # Basic normalization
+    filename = f"prescriptions_{department_filename_part}.csv"
+    # base_dir is defined above
+    filepath = os.path.join(base_dir, "data", filename) # Changed from "app", "data" to "data"
 
     if not os.path.exists(filepath):
         # Fallback to a generic prescriptions file if department-specific file doesn't exist
-        filepath = os.path.join("app", "data", "prescriptions.csv")
+        filepath = os.path.join(base_dir, "data", "prescriptions.csv") # Changed from "app", "data"
         if not os.path.exists(filepath):
-            return None # Or raise an error
+            # print(f"Error: Prescription details file not found (e.g., {filename} or prescriptions.csv).")
+            return None
 
     all_prescriptions_in_file = []
     try:
-        with open(filepath, mode='r', encoding='utf-8') as file:
+        # Use utf-8-sig for prescription files too, in case they have a BOM
+        with open(filepath, mode='r', encoding='utf-8-sig') as file:
             reader = csv.DictReader(file)
             for row in reader:
                 all_prescriptions_in_file.append(row)
     except FileNotFoundError:
-        return None # Or raise an error
-
-    if not all_prescriptions_in_file:
+        # print(f"Error: Prescription data file not found at {filepath}")
+        return None
+    except Exception as e:
+        # print(f"Error reading prescription data file {filepath}: {e}")
         return None
 
-    # The original logic selected a random number of prescriptions.
-    # We'll use the `last_prescriptions` passed from the session.
+    # This check means if prescription names were found in reservation, but no corresponding
+    # prescription detail file (e.g. treatment_fees.csv or prescriptions.csv) was loaded,
+    # it's an issue. However, to maintain behavior of showing N/A for missing details,
+    # we allow it to proceed. If `all_prescriptions_in_file` is empty, `med_detail` will be None.
+    # if not all_prescriptions_in_file and parsed_prescription_names:
+    #     print(f"Warning: Prescriptions listed for patient {patient_rrn}, but no details found in {filepath}.")
+    #     # Proceeding will result in N/A for details.
+
     selected_prescriptions = []
-    for med_name in last_prescriptions:
-        # Find the details for each prescribed medicine
-        med_detail = next((p for p in all_prescriptions_in_file if p['name'] == med_name), None)
-        if med_detail:
-            selected_prescriptions.append({
-                "name": med_detail["name"],
-                "code": med_detail["code"],
-                "unit_dose": med_detail.get("unit_dose", "1"), # Assuming default if not present
-                "daily_frequency": med_detail.get("daily_frequency", "1"), # Assuming default
-                "total_days": med_detail.get("total_days", "1"), # Assuming default
-            })
-        else:
-            # Handle case where a medicine from last_prescriptions is not found in the CSV
-            # This might indicate a data consistency issue or a need for a more robust lookup
-            selected_prescriptions.append({
-                "name": med_name,
-                "code": "N/A", # Or some other placeholder
-                "unit_dose": "N/A",
-                "daily_frequency": "N/A",
-                "total_days": "N/A",
-            })
+    if parsed_prescription_names: # Only try to find details if there are names from reservation
+        for med_name in parsed_prescription_names:
+            # Ensure 'name' in p is stripped for comparison, similar to parsed_prescription_names
+            med_detail = next((p for p in all_prescriptions_in_file if p.get('name', '').strip() == med_name), None)
+            if med_detail:
+                selected_prescriptions.append({
+                    "name": med_detail["name"], # Use the name from the details file for consistency
+                    "code": med_detail.get("code", "N/A"),
+                    "unit_dose": med_detail.get("unit_dose", "1"),
+                    "daily_frequency": med_detail.get("daily_frequency", "1"),
+                    "total_days": med_detail.get("total_days", "1"),
+                })
+            else:
+                # If a medicine name from reservation is not found in the details file
+                selected_prescriptions.append({
+                    "name": med_name, "code": "N/A", "unit_dose": "N/A",
+                    "daily_frequency": "N/A", "total_days": "N/A",
+                })
 
-
-    # Constructing the prescription data structure, patient details will be added later
+    # Constructing the prescription data structure
     prescription_data_template = {
-        "doctor_name": "김의사", # Placeholder
+        "doctor_name": "김의사", # Placeholder, ideally from reservation or doctor data
         "doctor_license_number": f"{random.randint(1000, 9999)}", # Placeholder
-        "department": department,
+        "department": department, # Passed as argument, originally from reservation
         "prescriptions": selected_prescriptions,
-        "total_fee": last_total_fee, # Use the fee from the session
+        "total_fee": fetched_total_fee, # Use the fee from reservations.csv
         "issue_date": datetime.now().strftime("%Y-%m-%d")
     }
     return prescription_data_template

--- a/data/reservations.csv
+++ b/data/reservations.csv
@@ -1,4 +1,4 @@
-name,rrn,time,department,location,doctor,status,transcription,amount
+name,rrn,time,department,location,doctor,status,prescription_names,total_fee
 류열다,970405-1660660,2025-06-19 08:20,소화기내과,2층 A-4,윤교경 전문의,Pending,,0
 황용용,810206-2331088,2025-06-25 05:50,비뇨의학과,2층 C-4,강수한 전문의,Pending,,0
 이린제,720528-1034254,2025-06-12 05:10,치과,3층 C-4,임범린 전문의,Pending,,0


### PR DESCRIPTION
…icates

This commit implements a significant change to how prescription and payment details are stored and used for certificate generation.

Key changes include:

1.  **`reservations.csv` Schema Update:**
    *   Renamed `transcription` column to `prescription_names`.
    *   Renamed `amount` column to `total_fee`.

2.  **Payment Service Enhancement:**
    *   Added `update_reservation_with_payment_details` function to
      `app/services/payment_service.py`. This function updates the
      patient's record in `reservations.csv` with a comma-separated
      list of `prescription_names` and the `total_fee` after a
      successful payment.

3.  **Payment Route Modification:**
    *   The `payment` route in `app/routes/payment.py` now calls
      `update_reservation_with_payment_details` after processing a
      payment, using details (patient_rrn, prescription names, total_fee)
      retrieved from the session.

4.  **Certificate Service Refactor:**
    *   The `get_prescription_data_for_pdf` function in
      `app/services/certificate_service.py` has been refactored.
      It no longer takes prescription lists and fees from session data
      directly. Instead, it accepts `patient_rrn` and `department`,
      reads the `prescription_names` (parsing them from the CSV string)
      and `total_fee` from the patient's record in `reservations.csv`.
      It then proceeds to look up detailed medication info as before.

5.  **Certificate Route Adjustment:**
    *   The `generate_prescription_pdf` route in `app/routes/certificate.py`
      has been updated to call the refactored `get_prescription_data_for_pdf`
      service function with `patient_rrn` and `department`. Dependencies
      on session variables `last_prescriptions` and `last_total_fee` for
      this purpose have been removed.

This change makes `reservations.csv` the source of truth for prescriptions and fees related to a patient's visit when generating certificates, ensuring that what was paid for is what is certified. Thorough manual testing of the reception-payment-certificate workflow is recommended to ensure data integrity.