### PR TITLE
Feat: Implement reservation status updates to 'Registered' and 'Paid'

### DIFF
--- a/app/services/payment_service.py
+++ b/app/services/payment_service.py
@@ -84,6 +84,7 @@ def update_reservation_with_payment_details(patient_rrn: str, prescription_names
                     rows[row_idx]['prescription_names'] = "" # Empty string if list is empty or None
 
                 rows[row_idx]['total_fee'] = str(total_fee) # Store total_fee as string
+                rows[row_idx]['status'] = "Paid" # <--- ADDED THIS LINE
                 updated = True
                 break
 


### PR DESCRIPTION
This commit introduces updates to the patient's reservation status in `reservations.csv` at key points in your workflow:

1.  **Payment Service (`app/services/payment_service.py`):**
    - The `update_reservation_with_payment_details` function now also sets the patient's `status` to 'Paid' when recording their prescription names and total fee after successful payment.

2.  **Reception Service (`app/services/reception_service.py`):**
    - Added a new function `update_reservation_status(patient_rrn, new_status)` to update the status of a given patient's reservation in `reservations.csv`.
    - Includes standard entry logging for the new function.

3.  **Reception Routes (`app/routes/reception.py`):**
    - The `reception` route now calls `update_reservation_status` with `new_status='Registered'`: - After successfully finding an existing reservation through ID scan (`handle_scan_action`). - After successfully finding an existing reservation through manual input (`handle_manual_action`). - After a new or walk-in patient successfully selects a symptom (`handle_choose_symptom_action`), confirming their registration for the current visit.

These changes ensure that the patient's status in `reservations.csv` accurately reflects their progression through the kiosk workflow.