### PR TITLE
Refine: Certificate generation error messages for status and fee

### DIFF
--- a/app/routes/certificate.py
+++ b/app/routes/certificate.py
@@ -91,6 +91,8 @@ def generate_prescription_pdf():
             headers={'Content-Disposition': f'inline;filename={filename}'}
         )
     # Handle error cases based on status_code from get_prescription_data_for_pdf
+    elif status_code == "NEEDS_RECEPTION_COMPLETION": # New condition
+        return render_template("error.html", message=result_payload), 400
     elif status_code in ["NEEDS_PAYMENT", "ZERO_FEE_PAID"]:
         # These are client-side correctable or informational errors
         return render_template("error.html", message=result_payload), 400


### PR DESCRIPTION
I've improved the error handling and feedback you receive for certificate generation:

1.  **Service Layer (`app/services/certificate_service.py`):**
    - `get_prescription_data_for_pdf` now distinguishes between different pre-payment statuses: - If `status` is 'Pending', it returns a "NEEDS_RECEPTION_COMPLETION" code with a message "접수를 먼저 완료해주세요. 현재 상태: Pending". - If `status` is other than 'Pending' or 'Paid' (e.g., 'Registered'), it returns "NEEDS_PAYMENT" with an appropriate message.
    - The check for 'Paid' status and non-positive `total_fee` remains.

2.  **Route Layer (`app/routes/certificate.py`):**
    - The `generate_prescription_pdf` route now specifically handles the "NEEDS_RECEPTION_COMPLETION" code from the service, displaying the corresponding message to you.

This provides more targeted guidance to you if you attempt to generate a certificate before completing reception or payment.