### PR TITLE
Fix: Correct TypeError in PDF generation and update content

### DIFF
--- a/app/utils/pdf_generator.py
+++ b/app/utils/pdf_generator.py
@@ -37,7 +37,7 @@ def _add_korean_font(pdf_instance):
         )
     )
 
-def create_prescription_pdf_bytes(patient_name, patient_rrn, department, prescriptions, total_fee):
+def create_prescription_pdf_bytes(patient_name, patient_rrn, department, prescriptions, total_fee, doctor_name, issue_date):
     pdf = FPDF()
     pdf.add_page()
     _add_korean_font(pdf)
@@ -49,8 +49,8 @@ def create_prescription_pdf_bytes(patient_name, patient_rrn, department, prescri
 
     # Header Information
     pdf.set_font_size(12)
-    current_date = datetime.now().strftime("%Y-%m-%d")
-    pdf.cell(0, 7, txt=f"발행일: {current_date}", ln=True, align="R")
+    # current_date = datetime.now().strftime("%Y-%m-%d") # Removed
+    pdf.cell(0, 7, txt=f"발행일: {issue_date}", ln=True, align="R") # Use issue_date parameter
     pdf.cell(0, 7, txt="기관명: 중앙대 보건소", ln=True)
     pdf.cell(0, 7, txt=f"환자 성명: {patient_name}", ln=True)
     pdf.cell(0, 7, txt=f"주민등록번호: {patient_rrn}", ln=True)
@@ -81,7 +81,7 @@ def create_prescription_pdf_bytes(patient_name, patient_rrn, department, prescri
 
     # Footer/Notes
     pdf.set_font_size(10)
-    pdf.multi_cell(0, 7, txt="위와 같이 처방합니다.\n\n\n의사명: 김중앙 (서명/날인)")
+    pdf.multi_cell(0, 7, txt=f"위와 같이 처방합니다.\n\n\n의사명: {doctor_name} (서명/날인)") # Use doctor_name parameter
     pdf.ln(5)
     pdf.cell(0, 7, txt="* 이 처방전은 발행일로부터 7일간 유효합니다.", ln=True)
 


### PR DESCRIPTION
This commit addresses a TypeError and updates prescription PDF content:

1.  **Fix TypeError (`app/services/certificate_service.py`):**
    - I modified `prepare_prescription_pdf` to explicitly pass arguments to `create_prescription_pdf_bytes` instead of using dictionary unpacking (`**kwargs`). This resolves the `TypeError` caused by unexpected keyword arguments.

2.  **Update PDF Content Source (`app/services/certificate_service.py`):**
    - `get_prescription_data_for_pdf` now extracts the `doctor` name and `time` (for issue date) from `reservations.csv`.
    - The reservation time is formatted as "YYYY-MM-DD" for the issue date.
    - These are included in the data passed for PDF generation.

3.  **Update PDF Generation Utility (`app/utils/pdf_generator.py`):**
    - The `create_prescription_pdf_bytes` function signature now accepts `doctor_name` and `issue_date` as parameters.
    - The PDF now uses these passed-in values for the doctor's name and the prescription's issue date, instead of placeholders or the current date for these fields.

This ensures correct argument passing for PDF generation and makes the doctor's name and issue date on the certificate reflect data from the patient's reservation.