### PR TITLE
Fix PDF filename encoding

### DIFF
--- a/app/routes/certificate.py
+++ b/app/routes/certificate.py
@@ -6,6 +6,7 @@ from flask import (
     Blueprint, render_template, session, redirect, url_for, Response
 )
 from werkzeug.http import dump_options_header # Added for Content-Disposition
+from urllib.parse import quote
 # Removed: request, jsonify as they are not used after refactoring
 # Removed: os, csv, random as their functionality is moved to service
 
@@ -86,10 +87,11 @@ def generate_prescription_pdf():
         except MissingKoreanFontError as e:
             return render_template("error.html", message=str(e)), 500
 
+        disposition = f"inline; filename*=UTF-8''{quote(filename)}"
         return Response(
             pdf_bytes,
             mimetype='application/pdf',
-            headers={'Content-Disposition': dump_options_header('inline', {'filename': filename})}
+            headers={'Content-Disposition': disposition}
         )
     # Handle error cases based on status_code from get_prescription_data_for_pdf
     elif status_code == "NEEDS_RECEPTION_COMPLETION": # New condition
@@ -140,8 +142,9 @@ def generate_confirmation_pdf():
     except MissingKoreanFontError as e:
         return render_template("error.html", message=str(e)), 500
 
+    disposition = f"inline; filename*=UTF-8''{quote(filename)}"
     return Response(
         pdf_bytes, # pdf_bytes is already BytesIO object from service
         mimetype='application/pdf',
-        headers={'Content-Disposition': dump_options_header('inline', {'filename': filename})}
+        headers={'Content-Disposition': disposition}
     )

--- a/tests/services/test_certificate_service.py
+++ b/tests/services/test_certificate_service.py
@@ -8,8 +8,8 @@ from datetime import datetime
 # Ensure the app module can be imported
 # This might need adjustment based on actual project structure and PYTHONPATH
 import sys
-# Assuming 'app' is in the parent directory of 'tests'
-# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+# Ensure the app package is importable during test collection
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
 from app.services.certificate_service import (
     get_prescription_data_for_pdf,
@@ -176,117 +176,3 @@ class TestCertificateService(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)
-
-# Note: The sys.path manipulation is a common workaround for running tests directly.
-# In a more structured project with a proper setup.py or tox/nox, this might not be needed.
-# Also, the MissingKoreanFontError and actual PDF creation functions are assumed to be importable
-# or are mocked. If they are in app.utils.pdf_generator, their patches would be like:
-# @patch('app.services.certificate_service.some_function_in_utils_pdf_generator') or
-# @patch('app.utils.pdf_generator.create_prescription_pdf_bytes') if used directly by service.
-# For this example, I've patched them as if they are part of 'app.services.certificate_service'
-# or globally available for patching.
-# The `create_prescription_pdf_bytes` and `create_confirmation_pdf_bytes` are imported into
-# `certificate_service.py` so they should be patched there:
-# e.g. @patch('app.services.certificate_service.create_prescription_pdf_bytes')
-# This is what I've done in the test_prepare_prescription_pdf and test_prepare_medical_confirmation_pdf.
-#
-# Also, the `random.randint` in `prepare_medical_confirmation_pdf` for `date_of_diagnosis` needs mocking
-# if we want to assert the exact date of diagnosis, or we can just check its presence.
-# I've added a mock for `random.randint` for the confirmation PDF test.
-#
-# The test_get_prescription_data_for_pdf_success_department_csv_exists had an issue with mock_open
-# side_effect. Corrected to simulate file reading properly for department specific and generic.
-# The `mock_open.return_value.read.return_value` is not how it works with `csv.DictReader`.
-# `mock_open` should be configured to provide an iterator for `csv.DictReader`.
-# Let's refine the CSV reading tests.
-
-# Re-refining CSV reading tests:
-# Instead of mock_open().read(), we need mock_open to work with `with open(...) as file:`
-# and then `csv.DictReader(file)`.
-# The `read_data` parameter of `mock_open` is good for this.
-
-# For test_get_prescription_data_for_pdf_success_department_csv_exists:
-# mock_file_open should be set for the specific department file.
-# `mock_file_open.return_value = mock_open(read_data=MOCK_CSV_DATA_DEPARTMENT_SPECIFIC).return_value` might not work directly.
-# The `side_effect` for `mock_file_open` needs to be a list of mock file objects if called multiple times.
-# Or, if called once, `mock_file_open.return_value = ...`
-
-# Let's assume the current mock_open usage with read_data in the test code is simplified
-# and would work with how csv.DictReader iterates over the file mock.
-# In a real scenario, this might need:
-# m = mock_open(read_data=...)
-# with patch('builtins.open', m):
-#   # call function
-# Or for multiple files:
-# m_dept = mock_open(read_data=MOCK_CSV_DATA_DEPARTMENT_SPECIFIC)
-# m_generic = mock_open(read_data=MOCK_CSV_DATA_PRESCRIPTIONS)
-# mock_file_open.side_effect = [m_dept.return_value, m_generic.return_value]
-# The current patch on `builtins.open` with `new_callable=mock_open` and then setting `read_data`
-# on `mock_file_open.return_value.read.return_value` is not quite right for csv.DictReader.
-# Corrected approach:
-# mock_file_open.return_value = io.StringIO(MOCK_CSV_DATA_DEPARTMENT_SPECIFIC)
-# Or, if `mock_open` is used directly:
-# with patch('builtins.open', mock_open(read_data=MOCK_CSV_DATA_DEPARTMENT_SPECIFIC)) as mocked_file:
-#    ...
-# The provided solution uses `mock_file_open.side_effect = [mock_open(read_data=...).return_value]`
-# which is a more robust way if multiple files are involved or complex logic.
-# For a single open call, `mock_file_open.return_value = mock_open(read_data=...).return_value` is okay.
-
-# My implementation of the tests for CSV reading:
-# I'll use `mock_open(read_data=...)` directly in the patch.
-
-# Correcting the CSV test patches:
-# Test 1: Department CSV exists
-# @patch('app.services.certificate_service.os.path.exists')
-# @patch('builtins.open', new_callable=mock_open)
-# def test_get_prescription_data_for_pdf_success_department_csv_exists(self, mock_file_open, mock_path_exists):
-#     mock_path_exists.side_effect = lambda p: p.endswith(f"prescriptions_{self.department.lower()}.csv")
-#     # Configure mock_open for the first (and only) call
-#     mock_file_open.return_value = mock_open(read_data=MOCK_CSV_DATA_DEPARTMENT_SPECIFIC).return_value
-#
-# This is still not quite right. `mock_open` itself should be the context manager or iterable.
-# The current code directly sets `mock_file_open.return_value.read.return_value`.
-# This is fine if the code being tested does `file.read()`. But `csv.DictReader` iterates.
-# The `read_data` argument to `mock_open` itself should handle this.
-# So, `mock_file_open.return_value = io.StringIO(MOCK_CSV_DATA_DEPARTMENT_SPECIFIC)` or
-# `with patch('builtins.open', mock_open(read_data=MOCK_CSV_DATA_DEPARTMENT_SPECIFIC)):`
-
-# The provided code is:
-# @patch('builtins.open', new_callable=mock_open)
-# ...
-# mock_csv_file = mock_open(read_data=MOCK_CSV_DATA_DEPARTMENT_SPECIFIC)
-# mock_file_open.side_effect = [mock_csv_file.return_value]
-# This should work. `mock_open(read_data=...)` creates a mock object that behaves like an open file.
-# Then `mock_file_open.side_effect` is set to return this mock file object when `open` is called.
-
-# The original test code for CSV has:
-# mock_file_open.return_value.read.return_value = MOCK_CSV_DATA_DEPARTMENT_SPECIFIC
-# This is incorrect for csv.DictReader.
-# I'll fix this in my code generation below.
-# The fix is to use `mock_open(read_data=...)` and assign its return value to the `open` call.
-# e.g. `mock_file_open.return_value = io.StringIO(MOCK_CSV_DATA_DEPARTMENT_SPECIFIC)` if `open` is called once.
-# Or `mock_file_open.side_effect = [io.StringIO(MOCK_CSV_DATA_DEPARTMENT_SPECIFIC)]`
-# My current code for the test already does this with `mock_csv_file = mock_open(read_data=...)` and then `mock_file_open.side_effect`. This is fine.
-# The issue might have been in my previous internal reasoning, not the generated code itself.
-# The generated code seems to try to mock it correctly.
-#
-# The problem statement's `mock_file_open.return_value.read.return_value` was an example of *incorrect* mocking for CSVs.
-# My generated code for `test_get_prescription_data_for_pdf_success_department_csv_exists`:
-#   mock_csv_file = mock_open(read_data=MOCK_CSV_DATA_DEPARTMENT_SPECIFIC)
-#   mock_file_open.side_effect = [mock_csv_file.return_value]
-# This is a correct way to use mock_open for a single file read when `open` is called within the function.
-# The `csv.DictReader` will then correctly iterate over the lines provided by `read_data`.
-#
-# Final check on the file path for `get_prescription_data_for_pdf`, it uses `os.path.join("app", "data", filename)`.
-# The test structure `tests/services/test_...` means the service code is likely in `app/services/...`.
-# The `sys.path.insert` is a common way to handle imports for such structures when running tests directly.
-# It assumes the `PYTHONPATH` or execution context allows `app.services...` to be found.
-# If running with `python -m unittest discover tests`, then `PYTHONPATH` should be set to the project root.
-# The `sys.path.insert` helps make the individual test file runnable.
-# I'll remove the `sys.path.insert` as it's generally better to configure PYTHONPATH or use a test runner that handles it.
-# For the tool environment, it should find `app` correctly.
-# I have removed the `sys.path.insert` line.Okay, this is a large subtask involving creating multiple test files and numerous test cases. I will proceed file by file.
-
-First, I'll create the `tests/services` directory. Since I can't create a directory directly, I'll create the first test file within that directory, which will implicitly create the directory structure.
-
-I'll start with `tests/services/test_certificate_service.py`.

--- a/tests/services/test_chatbot_service.py
+++ b/tests/services/test_chatbot_service.py
@@ -2,8 +2,11 @@ import unittest
 from unittest.mock import patch, MagicMock, ANY
 import os
 import base64
+import sys
 
-# Assuming the service is in app.services.chatbot_service
+# Ensure the app package is importable during test collection
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
 from app.services.chatbot_service import generate_chatbot_response, SYSTEM_INSTRUCTION_PROMPT
 
 class TestChatbotService(unittest.TestCase):

--- a/tests/services/test_payment_service.py
+++ b/tests/services/test_payment_service.py
@@ -2,6 +2,10 @@ import unittest
 from unittest.mock import patch, mock_open
 import os
 import uuid # For checking payment_id format, though not strictly necessary to mock uuid itself
+import sys
+
+# Ensure the app package is importable during test collection
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
 from app.services.payment_service import (
     process_new_payment,

--- a/tests/services/test_reception_service.py
+++ b/tests/services/test_reception_service.py
@@ -2,6 +2,10 @@ import unittest
 from unittest.mock import patch, mock_open, MagicMock
 import os
 from datetime import datetime
+import sys
+
+# Ensure the app package is importable during test collection
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
 from app.services.reception_service import (
     lookup_reservation,


### PR DESCRIPTION
## Summary
- URL-encode filenames in certificate routes so non-ASCII names work
- trim stray text in test file and make test modules importable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68452f7715e0832cbd1d5658581c47bd