### PR TITLE
fix: Correctly handle 'Pending' reservations in chatbot reception

### DIFF
--- a/app/services/reception_service.py
+++ b/app/services/reception_service.py
@@ -96,9 +96,11 @@ def new_ticket(department: str) -> str:
     return ticket_num
 
 
-def update_reservation_status(patient_rrn: str, new_status: str) -> bool:
+def update_reservation_status(patient_rrn: str, new_status: str, **kwargs) -> bool:
     """
     Updates the status of a patient's reservation in reservations.csv.
+    Can also update other reservation fields (e.g., 'department', 'ticket_number', 'name')
+    by passing them as keyword arguments. All values will be stored as strings.
     """
     _func_args = locals()
     _module_path = sys.modules[__name__].__name__ if __name__ in sys.modules else __file__
@@ -124,8 +126,18 @@ def update_reservation_status(patient_rrn: str, new_status: str) -> bool:
 
         for i, row in enumerate(rows):
             if row.get('rrn') == patient_rrn:
-                rows[i]['status'] = new_status
+                rows[i]['status'] = str(new_status) # Ensure status is also a string
+
+                # Update other fields from kwargs if they are valid column names
+                for key, value in kwargs.items():
+                    if key in original_fieldnames: # Ensure the key is a valid column
+                        rows[i][key] = str(value) # Store all CSV data as strings
+                    else:
+                        # Optional: Log a warning if a kwarg key is not a valid fieldname
+                        print(f"Warning: In update_reservation_status, '{key}' is not a valid field in reservations.csv. Cannot update.")
+
                 updated = True
+                # RRN should be unique, so we can break after finding and updating.
                 break
 
         if updated:


### PR DESCRIPTION
Modifies the AI chatbot's reception logic to correctly process patients whose reservations are in a "Pending" state. Previously, "Pending" was treated as an error. Now, it's treated as a valid state for check-in.

Key changes:

1.  **`app/services/chatbot_service.py` (`handle_reception_request`)**:
    *   If a patient's reservation status is "Pending":
        *   The department is retrieved from the reservation. If not
            available, the chatbot asks for the patient's symptom to
            determine the department (using `handle_choose_symptom_action`).
        *   A new ticket number is generated using
            `reception_service.new_ticket`.
        *   `reception_service.update_reservation_status` is called to
            change the status to "Registered" and update the department
            (if newly determined) and the new ticket number.
    *   Imports for `new_ticket` and `update_reservation_status` from
        `reception_service` were added.

2.  **`app/services/reception_service.py` (`update_reservation_status`)**:
    *   The function signature was changed to `(patient_rrn: str, new_status: str, **kwargs)`.
    *   It now iterates through `kwargs` (e.g., `department`,
        `ticket_number`, `name`) and updates these fields in the
        CSV row if the keys are valid column names. All values are
        stored as strings.
    *   The docstring was updated to reflect this new capability.

3.  **`tests/services/test_chatbot_service.py`**:
    *   Added new test cases to `TestChatbotServiceHandlers` to
        specifically verify the correct handling of "Pending" reservations.
        These tests cover scenarios where:
        *   The pending reservation includes a department.
        *   The pending reservation does not include a department, and you
            are prompted for a symptom.
        *   The pending reservation does not include a department, and you
            provide a symptom.
    *   Mocks for `lookup_reservation`, `new_ticket`,
        `update_reservation_status`, and `handle_choose_symptom_action`
        were used to assert correct function calls and responses.

This fix ensures that patients with pre-existing "Pending" reservations can be seamlessly checked in via the chatbot.