### PR TITLE
fix: Ensure project root is in sys.path in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,5 +1,12 @@
 import shutil
 import os
+import sys
+
+# Ensure the project root is in sys.path for robust imports
+project_root = os.path.abspath(os.path.dirname(__file__))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
 from app import create_app
 
 # --- Start of CSV reset logic ---


### PR DESCRIPTION
I've modified `run.py` to explicitly add the project's root directory (the directory containing `run.py` itself) to `sys.path`.

This is intended to resolve `ImportError: cannot import name 'create_app' from 'app'` by making the `app` package and its modules more reliably discoverable by Python, regardless of the directory from which `run.py` is executed or potential `PYTHONPATH` configurations.