### PR TITLE
fix: Explicitly pass reservation details to reception template

### DIFF
--- a/app/routes/reception.py
+++ b/app/routes/reception.py
@@ -36,9 +36,14 @@ def reception():
             session['patient_rrn'] = scan_result["rrn"]
 
             if scan_result["reservation_details"]:
-                update_reservation_status(scan_result["rrn"], 'Registered') # <--- ADDED THIS
+                update_reservation_status(scan_result["rrn"], 'Registered')
+                details = scan_result["reservation_details"]
                 return render_template("reception.html", step="reserved",
-                                       **scan_result["reservation_details"])
+                                   name=details.get("name"),
+                                   department=details.get("department"),
+                                   time=details.get("time"),
+                                   location=details.get("location"),
+                                   doctor=details.get("doctor"))
             else:
                 # If no reservation, they proceed to symptom choice. Status will be updated there.
                 return render_template("reception.html", step="symptom",
@@ -59,9 +64,14 @@ def reception():
             reservation_details = handle_manual_action(name, rrn) # Service returns dict or None
 
             if reservation_details:
-                update_reservation_status(rrn, 'Registered') # <--- ADDED THIS
+                update_reservation_status(rrn, 'Registered')
+                # Note: reservation_details is already the correct dictionary here
                 return render_template("reception.html", step="reserved",
-                                       **reservation_details)
+                                   name=reservation_details.get("name"),
+                                   department=reservation_details.get("department"),
+                                   time=reservation_details.get("time"),
+                                   location=reservation_details.get("location"),
+                                   doctor=reservation_details.get("doctor"))
             else:
                 # If no reservation, they proceed to symptom choice. Status will be updated there.
                 return render_template("reception.html", step="symptom",


### PR DESCRIPTION
I modified `app/routes/reception.py` to explicitly pass `name`, `department`, `time`, `location`, and `doctor` to the `reception.html` template when `step="reserved"`.

Previously, these details were passed by unpacking the `reservation_details` dictionary. While functionally similar if all keys are present, the explicit passing using `details.get("field_name")` enhances code clarity and robustness against potentially missing keys in the dictionary.

This change ensures that if the department (and other specified fields) is present in the reservation data from `reservations.csv`, it is correctly made available to the template for display.