### PR TITLE
feat: Implement PDF viewing for prescriptions and certificates in cha…

### DIFF
--- a/templates/chatbot_interface.html
+++ b/templates/chatbot_interface.html
@@ -268,6 +268,42 @@
                 appendMessage('bot', data.reply);
                 speak(data.reply);
 
+                // New code to handle PDF data
+                if (data.pdf_data_base64 && data.pdf_filename) {
+                    try {
+                        // Decode base64 string to binary data
+                        const byteCharacters = atob(data.pdf_data_base64);
+                        const byteNumbers = new Array(byteCharacters.length);
+                        for (let i = 0; i < byteCharacters.length; i++) {
+                            byteNumbers[i] = byteCharacters.charCodeAt(i);
+                        }
+                        const byteArray = new Uint8Array(byteNumbers);
+                        const blob = new Blob([byteArray], {type: 'application/pdf'});
+
+                        // Create a link element, set its href to the blob URL, and click it to open/download
+                        const link = document.createElement('a');
+                        link.href = URL.createObjectURL(blob);
+                        link.target = '_blank'; // Open in a new tab
+                        link.rel = 'noopener noreferrer'; // Security best practice
+                        // link.download = data.pdf_filename; // Optional: Suggest a filename for download
+
+                        // Simulate a click to open the PDF in a new tab
+                        // For a better user experience, consider creating a visible link or button
+                        // that the user can click, instead of an automatic popup.
+                        // However, the request implies opening it directly.
+                        link.click();
+
+                        // Clean up the blob URL after a short delay
+                        setTimeout(() => URL.revokeObjectURL(link.href), 100);
+
+                        // Optionally, notify the user that the PDF is being opened.
+                        // The main 'reply' from the bot should already indicate success.
+                        // appendMessage('system', `PDF '${data.pdf_filename}'가 새 창에서 열립니다.`);
+                    } catch (pdfError) {
+                        console.error('Error processing PDF data:', pdfError);
+                        appendMessage('system', 'PDF를 처리하는 중 오류가 발생했습니다.');
+                    }
+                }
             } catch (error) {
                 console.error('Error sending message:', error);
                 appendMessage('system', `메시지 전송 실패: ${error.message || '알 수 없는 오류'}`);


### PR DESCRIPTION
…tbot

I've modified the chatbot interface to handle PDF data returned from the backend. When you request a prescription or medical certificate and the system successfully generates it, I will now:

1.  Display a confirmation message in the chat.
2.  Automatically open the generated PDF document in a new browser tab.

This functionality relies on the backend providing the PDF content as a base64 encoded string (`pdf_data_base64`) and a filename (`pdf_filename`) in the JSON response. The frontend JavaScript has been updated to decode this data and trigger the new tab opening.

The `chatbot_service.py` already provided the necessary PDF data in its response structure for certificate generation, so no backend changes were needed for this part.