### PR TITLE
fix: Remove filename from chatbot PDF confirmation messages

### DIFF
--- a/app/services/chatbot_service.py
+++ b/app/services/chatbot_service.py
@@ -478,7 +478,7 @@ def handle_certificate_request(parameters: dict, user_query: str) -> dict:
             if pdf_bytes and filename:
                 pdf_base64 = base64.b64encode(pdf_bytes).decode('utf-8')
                 return {
-                    "reply": f"{name}님의 처방전 발급이 완료되었습니다. 파일명: {filename}",
+                    "reply": f"{name}님의 처방전 발급이 완료되었습니다. 새 창에서 확인해주세요.",
                     "pdf_filename": filename,
                     "pdf_data_base64": pdf_base64  # For the API to send to client
                 }
@@ -502,7 +502,7 @@ def handle_certificate_request(parameters: dict, user_query: str) -> dict:
             if pdf_bytes and filename:
                 pdf_base64 = base64.b64encode(pdf_bytes).decode('utf-8')
                 return {
-                    "reply": f"{name}님의 진료확인서 발급이 완료되었습니다. 파일명: {filename}",
+                    "reply": f"{name}님의 진료확인서 발급이 완료되었습니다. 새 창에서 확인해주세요.",
                     "pdf_filename": filename,
                     "pdf_data_base64": pdf_base64 # For the API to send to client
                 }


### PR DESCRIPTION
I updated the `handle_certificate_request` function in `app/services/chatbot_service.py` to provide you with a cleaner experience.

When a PDF for a prescription or medical certificate is generated, the confirmation message displayed in the chat interface no longer includes the explicit filename. Instead, it uses a more generic message like "Your [document type] has been issued. Please check the new window."

The actual `pdf_filename` and `pdf_data_base64` are still returned in the backend JSON response, ensuring that the frontend can continue to open the PDF in a new tab as implemented previously. This change only affects the textual reply shown in the chat history.