### PR TITLE
feat: Add favicon to the website

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}보건소 키오스크{% endblock %}</title>
+    <link rel="icon" href="{{ url_for('static', filename='images/CAU-heath-icon.webp') }}" type="image/webp">
 
     <!-- 정적 파일 -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">


### PR DESCRIPTION
This commit adds a favicon to the website.
The favicon is located at static/images/CAU-heath-icon.webp and is now linked in the base.html template. This will ensure that the CAU health icon is displayed in the browser tab and bookmarks.