### PR TITLE
Apply background image globally

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -15,7 +15,8 @@ html, body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
   "Helvetica Neue", Arial, "Noto Sans KR", "Apple SD Gothic Neo",
   "Malgun Gothic", sans-serif;
-  background: #f4f7fa;
+  background: #f4f7fa url("../images/CNU-health-background.webp") no-repeat center center fixed;
+  background-size: cover;
   color: #222;
 }
 


### PR DESCRIPTION
## Summary
- add `CNU-health-background.webp` as default background for all pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845895a7b00832cb33443a04cfa2666