### PR TITLE
Fix static folder path for correct logo serving

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,8 +7,8 @@ def create_app() -> Flask:
     """
     app = Flask(
         __name__,
-        static_folder="static",
-        template_folder="templates",
+        static_folder="../static",
+        template_folder="../templates",
     )
 
     # (선택) 세션 암호키 – 실제 서비스에서는 환경 변수로 관리 권장


### PR DESCRIPTION
## Summary
- ensure Flask serves project-level `static` and `templates` directories

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68458ff0380c832c8a26c938ccbb409f