### PR TITLE
Fix: Optimize background image and update home page icon

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -16,7 +16,6 @@ html, body {
   "Helvetica Neue", Arial, "Noto Sans KR", "Apple SD Gothic Neo",
   "Malgun Gothic", sans-serif;
   background: #f4f7fa url("../images/CNU-health-background.webp") no-repeat center center fixed;
-  background-size: cover;
   color: #222;
 }
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -8,7 +8,7 @@
 <div class="home-container" style="display:flex; flex-direction:column; align-items:center; margin-top:50px;">
     <!-- 로고 + 제목 -->
     <div class="logo-and-title" style="display:flex; align-items:center; margin-bottom:30px;">
-        <img src="{{ url_for('static', filename='images/logo.png') }}" alt="보건소 로고"
+        <img src="{{ url_for('static', filename='images/CAU-health-icon.webp') }}" alt="CAU Health Icon"
              style="width:120px; height:auto; margin-right:20px;">
         <h1 style="font-size:2.5rem; margin:0;">{{ locale.get('home_title', '보건소에 오신 것을 환영합니다') }}</h1>
     </div>


### PR DESCRIPTION
- I modified `static/css/style.css` to load the background image at its original resolution. This addresses the issue of the background image resolution being too large.
- I updated `templates/home.html` to use `CAU-health-icon.webp` as the icon on the first page, replacing the previous `logo.png`. The alt text for the icon has also been updated.