### PR TITLE
Fix background image scaling

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -16,6 +16,7 @@ html, body {
   "Helvetica Neue", Arial, "Noto Sans KR", "Apple SD Gothic Neo",
   "Malgun Gothic", sans-serif;
   background: #f4f7fa url("../images/CNU-health-background.webp") no-repeat center center fixed;
+  background-size: contain;
   color: #222;
 }
 


### PR DESCRIPTION
## Summary
- adjust body background to `contain` size so the background image isn't oversized

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684595d2e10c832c81840afabf8ae0da