### PR TITLE
Center header icons

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -47,6 +47,7 @@ body.font-large  * {
   border-bottom: 1px solid #d7e1ec;
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
   padding: 0 12px;
   z-index: 1000;


### PR DESCRIPTION
## Summary
- center header icons on all pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684596f3c390832c8f4e761f91c54492